### PR TITLE
Adds build-essential and python-dev to required packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get install -y \
     libgeos-dev \
     python3-lxml \
     libgdal-dev \
+    build-essential \
+    python-dev \
     python3-shapely \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Since `uwsgi` requires `build-essential` and `python-dev` (see also [here](https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html#installing-uwsgi-with-python-support)), we need to install this as well 

Plz review @terrestris/devs 