### PR TITLE
Adds missing python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     python3-shapely \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install MapProxy==1.15.1 pyproj uwsgi
+RUN pip install MapProxy==1.15.1 pyproj uwsgi six werkzeug
 
 EXPOSE 8080
 


### PR DESCRIPTION
This PR adds missing  python dependencies `six` and `werkzeug` to `Dockerfile`. This is required to get mapproxy getting properly started.

Plz review @terrestris/devs 